### PR TITLE
Uhm... sigh, legit spent 3+ hours trying to get this to work.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ proving_grounds/*
 *.gem
 Gemfile.lock
 todo
+coverage

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,6 @@
+simplecov_file = File.expand_path 'spec/simplecov'
+ENV['RUBYOPT'] = "-r#{simplecov_file}"
+
 desc 'run specs'
 task :spec do
   sh 'rspec -cf d --fail-fast'
@@ -22,8 +25,19 @@ namespace :spec do
   end
 end
 
+desc 'Show most recent test run\'s code coverage'
+task :coverage do
+  require 'simplecov'
+  require 'simplecov-html'
+  SimpleCov.result.format!
+end
+
+task :reset_coverage do
+  rm_r 'coverage'
+end
+
 desc 'Run work in progress specs and cukes'
 task wip: ['spec:wip', 'cuke:wip']
 
 desc 'Run all specs and cukes'
-task default: [:spec, :cuke]
+task default: [:reset_coverage, :spec, :cuke, :coverage]

--- a/seeing_is_believing.gemspec
+++ b/seeing_is_believing.gemspec
@@ -21,11 +21,12 @@ Gem::Specification.new do |s|
 
   s.add_dependency             "parser",   ">= 2.2.0.2", "< 3.0"
 
-  s.add_development_dependency "haiti",    ">= 0.1", "< 0.3"
-  s.add_development_dependency "rake",     "~> 10.0"
-  s.add_development_dependency "rspec",    "~>  3.0"
-  s.add_development_dependency "cucumber", "~>  1.2"
-  s.add_development_dependency "ichannel", "~>  5.1"
+  s.add_development_dependency "haiti",     ">= 0.1", "< 0.3"
+  s.add_development_dependency "rake",      "~> 10.0"
+  s.add_development_dependency "rspec",     "~>  3.0"
+  s.add_development_dependency "cucumber",  "~>  1.2"
+  s.add_development_dependency "ichannel",  "~>  5.1"
+  s.add_development_dependency "simplecov", "~>  0.9"
 
   s.post_install_message = <<'Omg, frogs <3'.gsub(/(gg+)/) { |capture| "\e[32m#{capture.gsub 'g', '.'}\e[0m" }.gsub("brown", "\e[33m").gsub("off", "\e[0m")
               .7

--- a/spec/simplecov.rb
+++ b/spec/simplecov.rb
@@ -1,0 +1,17 @@
+puts "SIMPLECOV LOADED"
+
+# no_defaults loads the lib without its at_exit hook
+# (the at_exit hook calls Kernel.exit, which raises a SystemExit, overriding whatever the file raised)
+require 'simplecov/no_defaults'
+
+# b/c we aren't getting their at_exit hook,
+# nothing will write the result to the coverage directory
+at_exit { SimpleCov.result.format! }
+
+null_formatter = Class.new { def format(*) end }
+SimpleCov.start do
+  self.formatter = null_formatter
+  add_filter "/spec/"
+  add_filter "/features/"
+end
+


### PR DESCRIPTION
SimpleCov has like 50 places you can enter it, all with some implicit
knowledge about the environment. It keeps overriding exit statuses,
but not in reliably reproducable ways (e.g. I run the suite, it blows up,
I run the one spec, it's fine). It calls Kernel.exit, overriding
the error that SiB needs to record. I tried to clean it up, but moving
one line to another in a way that should absolutely not matter, winds
up causing its tests to fail. This is because it stores all its sate
in singletons, so somehow something happening in the interim was going
and mutating it.

IDK, coverage API looks pretty simple, and SimpleCov breaks down as soon
as you deviate from its expectation, so if I really care about this, I'll
probably just write my own and see if I can't use their formatter for
inspecting it.

I will give it this, though: when I didn't shoot for 100% and thus
didn't try to get it to consolidate its result across processes, then it
didn't blow up, and the info I got from that was useful.

But srsly, kill off the singletons.